### PR TITLE
Add -pen to device name to be IDed as a pen by GDK

### DIFF
--- a/usb-driver.py
+++ b/usb-driver.py
@@ -54,7 +54,7 @@ cap = {
         (e.ABS_X, AbsInfo(value=minxpos, min=maxxpos, max=0, fuzz=0, flat=0, resolution=0)),
         (e.ABS_Y, AbsInfo(value=minypos, min=maxypos, max=0, fuzz=0, flat=0, resolution=0))]
 }
-ui = UInput(cap, name='boogie-board-sync')
+ui = UInput(cap, name='boogie-board-sync-pen')
 
 try:
     while True:


### PR DESCRIPTION
Thanks a lot for this tool! I was surprised how easy it was to get it up and running.

I ran into an issue when I was trying it out in Inkscape in that Inkscape completely ignored any variations in pressure and used maximum width all the time.

I tracked down the cause to be the combination of the following:
- Inkscape does not treat devices whose `Gdk::InputSource` is `Gdk::SOURCE_MOUSE` as extended input devices capable of pressure sensitivity (at the very least, it does not manage the configuration of such devices, as seen in http://bazaar.launchpad.net/~inkscape.dev/inkscape/trunk/view/head:/src/device-manager.cpp#L370)
- GDK relies on the name of the device to distinguish whether it is a simple mouse or a Wacom-like tablet with a stylus (https://git.gnome.org/browse/gtk+/tree/gdk/x11/gdkdevicemanager-xi2.c#n393).

I tried changing the device name from `boogie-board-sync` to `boogie-board-sync-pen` and it results in pressure sensitivity working great in Inkscape.
